### PR TITLE
Updated to 2.17.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "asyncssh" %}
-{% set version = "2.13.0" %}
-{% set sha256 = "be7e1cb47225dc9899e56472fdc4daac03584a6843675329c0ce67179cb20e29" %}
+{% set version = "2.17.0" %}
+{% set sha256 = "3b159c105aa388c1e2245c4faf483f540ada8cad99402281119100166e5edb3c" %}
 
 package:
   name: {{ name }}
@@ -12,29 +12,58 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
 
 requirements:
   host:
-    - python >=3.4
+    - python
     - setuptools
     - pip
+    - wheel
   run:
-    - python >=3.4
-    - cryptography
-    - pyopenssl >=17.0.0
-    - python-gssapi >=1.2.0
-    - typing_extensions >=3.6
+    - python
+    - cryptography >=39.0
+    - typing_extensions >=4.0.0
+  run_constrained:
+    # https://github.com/ronf/asyncssh/blob/master/README.rst#optional-extras
+    - bcrypt >=3.1.3
+    - fido2 >=0.9.2
+    - gssapi >=1.2.0
+    - libnacl >=1.4.2
+    - python-pkcs11 >=0.7.0
+    - pyopenssl >=23.0.0
+    - pywin32 >=227  # [win]    
 
 test:
+  requires:
+    - pip
+    - pytest >=7.0.1
+    - bcrypt >=3.1.3
+    - pyopenssl >=17.0.0
+    - uvloop >=0.9.1  # [unix]
+    - pywin32 >=227   # [win]
   imports:
     - asyncssh
+    - asyncssh.crypto
+  source_files:
+    - tests
+  commands:
+    - pip check
+    # Windows tests take days in CI and Linux fails things that pass locally.
+    - pytest -v tests -k "not (test_utime or test_forward_local_port_pause or test_ssh_listen_tunnel_default_port or test_setstat_v4)"  # [osx]
 
 about:
   home: https://github.com/ronf/asyncssh
-  license: EPL-1.0
-  summary: 'AsyncSSH: Asynchronous SSHv2 client and server library'
+  license: EPL-2.0
+  license_family: Other
+  license_file: LICENSE
+  summary: Asynchronous SSHv2 client and server library
+  description: |
+    AsyncSSH is a Python package which provides an asynchronous client and server implementation of the SSHv2 protocol
+    on top of the Python 3.6+ asyncio framework.
+  doc_url: https://asyncssh.readthedocs.io
+  dev_url: https://github.com/ronf/asyncssh
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
asyncssh 2.17.0

**Destination channel:** defaults

### Links

- [PKG-5940](https://anaconda.atlassian.net/browse/PKG-5940)
- [Upstream repository](https://github.com/ronf/asyncssh/tree/v2.17.0)
- [Upstream changelog/diff](https://github.com/ronf/asyncssh/compare/v2.13.0...v2.17.0)
- Relevant dependency PRs:
  - AnacondaRecipes/spyder-feedstock#24

### Explanation of changes:

- Added optional deps
- Added unit tests
  - Many scp/port checks fail in CI on Linux and Windows. Those tests have been skipped.


[PKG-5940]: https://anaconda.atlassian.net/browse/PKG-5940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ