### PR TITLE
asyncssh 2.21.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,18 @@
 {% set name = "asyncssh" %}
-{% set version = "2.17.0" %}
-{% set sha256 = "3b159c105aa388c1e2245c4faf483f540ada8cad99402281119100166e5edb3c" %}
+{% set version = "2.21.1" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9943802955e2131536c2b1e71aacc68f56973a399937ed0b725086d7461c990c
 
 build:
   number: 0
-  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  skip: True  # [py<36]
 
 requirements:
   host:
@@ -26,9 +25,8 @@ requirements:
     - cryptography >=39.0
     - typing_extensions >=4.0.0
   run_constrained:
-    # https://github.com/ronf/asyncssh/blob/master/README.rst#optional-extras
     - bcrypt >=3.1.3
-    - fido2 >=0.9.2
+    - fido2 >=0.9.2,<2
     - gssapi >=1.2.0
     - libnacl >=1.4.2
     - python-pkcs11 >=0.7.0


### PR DESCRIPTION
asyncssh 2.21.1 

**Destination channel:** Defaults

### Links

- [PKG-10663]
- dev_url:        https://github.com/ronf/asyncssh/tree/v2.21.1
- conda_forge:    https://github.com/conda-forge/asyncssh-feedstock
- pypi:           https://pypi.org/project/asyncssh/2.21.1
- pypi inspector: https://inspector.pypi.io/project/asyncssh/2.21.1

### Explanation of changes:

- new version number


[PKG-10663]: https://anaconda.atlassian.net/browse/PKG-10663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ